### PR TITLE
Fix compilation error

### DIFF
--- a/static_map/Cargo.toml
+++ b/static_map/Cargo.toml
@@ -12,3 +12,4 @@ authors = ["Christopher Breeden <github@u.breeden.cc>"]
 
 [dependencies]
 fxhash = "0.2.1"
+static_map_macros = {version="0.2.0-beta", path="../static_map_macros"}

--- a/static_map_macros/src/lib.rs
+++ b/static_map_macros/src/lib.rs
@@ -12,8 +12,8 @@ use builder::Builder;
 type Key<'a> = syn::Lit;
 type Value<'a> = &'a str;
 
-const LEADING: &str = "enum __StaticMap__ {\n    A =\n        static_map!(@ zero";
-const TRAILING: &str = "),\n}";
+const LEADING: &str = "enum __StaticMap__\n{\n    A = static_map !\n    (@ zero";
+const TRAILING: &str = ")\n}";
 
 fn trim(input: &str) -> &str {
     assert!(input.starts_with(LEADING));


### PR DESCRIPTION
Running `cargo test`on the library resulted in compilation errors:

```
error: proc-macro derive panicked
   --> static_map_macros/tests/tests.rs:11:56
    |
11  |   static CSS_COLORS_STATIC_MAP: Map<&'static str, RGB> = static_map! {
    |  ________________________________________________________^
12  | |     Default: RGB(0x00,0x00,0x00),
13  | |     "black" => RGB(0x00,0x00,0x00),
14  | |     "silver" => RGB(0xc0,0xc0,0xc0),
...   |
160 | |     "rebeccapurple" => RGB(0x66,0x33,0x99),
161 | | };
    | |_^
    |
    = help: message: assertion failed: input.starts_with(LEADING)
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR fixes them